### PR TITLE
Update composer.json to to avoid conflicts with an outdated library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^5.3.3 || ^7.0",
-        "fzaninotto/faker": "~1"
+        "fakerphp/faker": "~1"
     },
     "require-dev": {
       "phpunit/phpunit": "*"


### PR DESCRIPTION
fzaninotto/faker is archived and it is recomended to use newly created faker library which is called fakerphp/faker. It is impossible to install this library with fzaninotto/faker because fakerphp/faker caonflicts with it.